### PR TITLE
remove paragonie/random_compat reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "goaop/framework": "^2",
         "mockery/mockery": "^1.3",
         "moontoast/math": "^1.1",
-        "paragonie/random-lib": "^2",
         "php-mock/php-mock-mockery": "^1.3",
         "php-mock/php-mock-phpunit": "^2.5",
         "php-parallel-lint/php-parallel-lint": "^1.1",
@@ -44,7 +43,6 @@
         "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
         "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
         "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type.",
-        "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Remove reference to paragonie/random_compat

## Description

Remove reference to paragonie/random_compat - this library only applies before php 7 (https://github.com/paragonie/random_compat/commit/35469243ebbb9be5086cff57538cac6da2c36852)  and base uuid has been bumped to require php 7.2

## Motivation and context

tidying unnecessary module loading
